### PR TITLE
Remove special case for LEGR and JUNG

### DIFF
--- a/vector/src/main/java/lt/lrv/basemap/layers/Transportation.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/Transportation.java
@@ -34,8 +34,6 @@ public class Transportation implements OpenMapTilesSchema.Transportation, Forwar
                     addTransportationFeature(FieldValues.CLASS_PRIMARY, null, 4, sf, features);
                 } else if (tipas == 3) {
                     addTransportationFeature(FieldValues.CLASS_SECONDARY, null, 8, sf, features);
-                } else if (tipas == 7 && (paskirtis.equals("JUNG") || paskirtis.equals("LEGR"))) {
-                    addTransportationFeature(FieldValues.CLASS_SECONDARY, null, 12, sf, features);
                 } else if (tipas == 4) {
                     addTransportationFeature(FieldValues.CLASS_TERTIARY, null, 8, sf, features);
                 } else if (tipas == 6 || tipas == 8) {


### PR DESCRIPTION
Partially solves https://github.com/govlt/national-basemap/issues/59

This pull request has slight negative impact for some higher type roads connections. 

However, I believe that resolving inaccuracies within the city center, where incorrect connections are particularly glaring is better. The issue with such connections should be fixed in GRPK data source (it's impossible to solve it completely on our side). 

# After (good)
<img width="1145" alt="Screenshot 2024-04-22 at 11 45 06" src="https://github.com/govlt/national-basemap/assets/3719141/f9ef1b5b-ad8d-4076-9076-f48b506e69d9">

# After (negative)
<img width="872" alt="Screenshot 2024-04-22 at 11 45 51" src="https://github.com/govlt/national-basemap/assets/3719141/9945c59f-b805-4412-a7c6-947658cacd4d">
<img width="998" alt="Screenshot 2024-04-22 at 11 47 21" src="https://github.com/govlt/national-basemap/assets/3719141/a0fff474-90e8-47a5-ac60-e0062988b0c1">
