### PR TITLE
Correct buffer size for transportation names

### DIFF
--- a/vector/src/main/java/lt/lrv/basemap/Basemap.java
+++ b/vector/src/main/java/lt/lrv/basemap/Basemap.java
@@ -69,7 +69,7 @@ public class Basemap extends ForwardingProfile {
                                 new Place(),
                                 new Poi(),
                                 new Transportation(),
-                                new TransportationName(),
+                                new TransportationName(config),
                                 new Water(),
                                 new WaterName(),
                                 new Waterway(),

--- a/vector/src/main/java/lt/lrv/basemap/layers/TransportationName.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/TransportationName.java
@@ -5,6 +5,7 @@ import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
 import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import lt.lrv.basemap.openmaptiles.OpenMapTilesSchema;
 import lt.lrv.basemap.utils.LanguageUtils;
@@ -15,6 +16,12 @@ import java.util.List;
 import static com.onthegomap.planetiler.util.LanguageUtils.nullIfEmpty;
 
 public class TransportationName implements OpenMapTilesSchema.TransportationName, ForwardingProfile.FeaturePostProcessor {
+
+    final PlanetilerConfig config;
+
+    public TransportationName(PlanetilerConfig config) {
+        this.config = config;
+    }
 
     @Override
     public void processFeature(SourceFeature sf, FeatureCollector features) {
@@ -64,15 +71,11 @@ public class TransportationName implements OpenMapTilesSchema.TransportationName
 
     @Override
     public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) {
-        if (zoom >= 14) {
-            return FeatureMerge.mergeMultiLineString(items);
-        }
-
         return FeatureMerge.mergeLineStrings(
                 items,
-                0.5, // after merging, remove lines that are still less than 0.5px long
-                0.1, // simplify output linestrings using a 0.1px tolerance
-                4.0 // remove any detail more than 4px outside the tile boundary
+                config.minFeatureSize(zoom),
+                config.tolerance(zoom),
+                BUFFER_SIZE
         );
     }
 }


### PR DESCRIPTION
# After
```
                      z2    z3    z4    z5    z6    z7    z8    z9   z10   z11   z12   z13   z14   all
     transportation  492   754  3.3k  5.6k  9.9k   13k   19k   10k  8.9k   13k   14k   10k    7k   19k
transportation_name    0     0     0     0  9.4k   19k   19k   11k   11k  8.9k  5.6k  2.8k  7.5k   19k
          full tile  492   754  3.3k  5.6k   19k   32k   38k   22k   20k   18k   19k   12k   12k   38k
            gzipped  429   643  2.6k  4.5k   13k   22k   28k   17k   16k   15k   15k   10k  8.7k   28k
0:00:12 DEB [archive] -    Max tile: 38k (gzipped: 28k)
0:00:12 DEB [archive] -    Avg tile: 5.6k (gzipped: 4.5k) using weighted average based on OSM traffic
```

# Before
```
                      z2    z3    z4    z5    z6    z7    z8    z9   z10   z11   z12   z13   z14   all
     transportation  492   754  3.3k  5.6k  9.9k   13k   19k   10k  8.9k   13k   14k   10k    7k   19k
transportation_name    0     0     0     0   19k   23k   20k   11k   11k  8.6k  5.3k  2.7k  8.7k   23k
          full tile  492   754  3.3k  5.6k   29k   36k   39k   22k   20k   18k   19k   12k   13k   39k
            gzipped  428   643  2.6k  4.5k   19k   24k   29k   17k   16k   15k   15k   10k  8.8k   29k
0:00:11 DEB [archive] -    Max tile: 39k (gzipped: 29k)
0:00:11 DEB [archive] -    Avg tile: 5.9k (gzipped: 4.6k) using weighted average based on OSM traffic
```