### PR TITLE
Transport names without ref only from 12 min zoom

### DIFF
--- a/vector/src/main/java/lt/lrv/basemap/layers/TransportationName.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/TransportationName.java
@@ -52,8 +52,9 @@ public class TransportationName implements OpenMapTilesSchema.TransportationName
                     .setMinZoom(minZoom)
                     .setSortKeyDescending(minZoom);
         } else {
+            var minZoom = Math.max(12, Math.min(transportMinZoom + 2, 14));
             feature.putAttrs(LanguageUtils.getNames(sf.tags()))
-                    .setMinZoom(Math.min(transportMinZoom + 2, 14));
+                    .setMinZoom(minZoom);
         }
     }
 


### PR DESCRIPTION
In styles transport names without ref are shows only from zoom level 12. There is no need to emit them from lower zoom levels. 

### Before
```
0:05:49 DEB [archive] - Max tile sizes
                      z0    z1    z2    z3    z4    z5    z6    z7    z8    z9   z10   z11   z12   z13   z14   all
           boundary  382   448   565   833   894  3.7k  5.8k  5.3k  3.2k  2.5k  1.8k  2.2k  1.7k  1.6k  1.4k  5.8k
              place  530   452   452   452   910   910  4.8k  4.8k  3.8k  1.4k   591   551  7.3k  2.6k   974  7.3k
     transportation    0     0   491   753  3.3k  5.6k  9.9k   13k   19k   10k  8.9k   13k   14k   10k    7k   19k
              water    0     0    61    70    98   261    2k  5.2k   14k   15k   11k  9.6k  7.4k  5.2k  6.2k   15k
          landcover    0     0     0     0     0     0   879   18k   32k   37k   27k   24k   26k   19k   15k   37k
transportation_name    0     0     0     0     0     0  9.4k   19k   19k   11k   11k  8.9k  5.6k  2.8k  7.5k   19k
         water_name    0     0     0     0     0     0   209   242   299   381   455   415    1k  1.3k  1.9k  1.9k
            landuse    0     0     0     0     0     0     0    99   144   364  5.5k   17k   12k   10k   10k   17k
    aerodrome_label    0     0     0     0     0     0     0     0   284   209   271   271   209   209   182   284
           waterway    0     0     0     0     0     0     0     0     0   27k   14k   11k  8.5k  5.5k  3.4k   27k
            aeroway    0     0     0     0     0     0     0     0     0     0  1.2k  1.5k  1.3k  1.8k  1.5k  1.8k
           building    0     0     0     0     0     0     0     0     0     0     0  5.4k   28k   33k   50k   50k
               park    0     0     0     0     0     0     0     0     0     0     0     0  9.8k  6.1k  3.5k  9.8k
                poi    0     0     0     0     0     0     0     0     0     0     0     0    6k  2.8k  1.4k    6k
 forest_compartment    0     0     0     0     0     0     0     0     0     0     0     0     0  5.7k  4.3k  5.7k
        housenumber    0     0     0     0     0     0     0     0     0     0     0     0     0     0   17k   17k
              power    0     0     0     0     0     0     0     0     0     0     0     0     0     0   592   592
          full tile  912   900  1.5k  2.1k  5.1k   10k   33k   65k   85k   78k   57k   58k   79k   63k   83k   85k
            gzipped  546   575    1k  1.5k  3.8k  7.8k   23k   47k   65k   61k   46k   46k   60k   50k   64k   65k
0:05:49 DEB [archive] -    Max tile: 85k (gzipped: 65k)
0:05:49 DEB [archive] -    Avg tile: 23k (gzipped: 18k) using weighted average based on OSM traffic
```