### PR TITLE
Show buildings only from minzoom 13

### DIFF
--- a/vector/src/main/java/lt/lrv/basemap/layers/Building.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/Building.java
@@ -17,7 +17,9 @@ public class Building implements OpenMapTilesSchema.Building, ForwardingProfile.
     @Override
     public void processFeature(SourceFeature sf, FeatureCollector features) {
         if (sf.getSource().equals(Source.GRPK) && sf.getSourceLayer().equals(Layers.GRPK_PASTAT) && sf.canBePolygon()) {
-            features.polygon(this.name()).setBufferPixels(BUFFER_SIZE).setMinZoom(11);
+            features.polygon(this.name())
+                    .setBufferPixels(BUFFER_SIZE)
+                    .setMinZoom(13);
         }
     }
 


### PR DESCRIPTION
Prior to this pull request, buildings were displayed from zoom level 11 onwards. However, it may be unnecessary to render buildings at such low zoom levels, suggesting they should only be rendered from a minimum zoom level of 13.