### PR TITLE
Extend settlements classification using types and population

### DIFF
--- a/vector/src/main/java/lt/lrv/basemap/layers/Place.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/Place.java
@@ -7,35 +7,62 @@ import lt.lrv.basemap.constants.Source;
 import lt.lrv.basemap.openmaptiles.OpenMapTilesSchema;
 import lt.lrv.basemap.utils.LanguageUtils;
 
+import java.util.List;
+import java.util.Objects;
+
 public class Place implements OpenMapTilesSchema.Place {
 
     @Override
     public void processFeature(SourceFeature sf, FeatureCollector features) {
         if (sf.getSource().equals(Source.GRPK) && sf.getSourceLayer().equals(Layers.GRPK_VIETOV_T) && sf.isPoint()) {
             var code = sf.getString("GKODAS");
+            var adm_type = sf.getString("ADM_TIP");
+            var pop = sf.getLong("GYVSK");
 
             // TODO: add ANTR at higher zoom levels
             if (sf.getString("ANTR", "").isEmpty()) {
-                switch (code) {
-                    case "uas1" -> addFeature(FieldValues.CLASS_COUNTRY, 0, sf, features);
-                    case "uas2" -> addFeature(FieldValues.CLASS_PROVINCE, 4, sf, features);
-                    case "uas511" -> addFeature(FieldValues.CLASS_CITY, 6, sf, features);
-                    case "uas512" -> addFeature(FieldValues.CLASS_TOWN, 11, sf, features);
-                    case "uas52" -> addFeature(FieldValues.CLASS_VILLAGE, 12, sf, features);
-                    case "uas53" -> addFeature(FieldValues.CLASS_SUBURB, 13, sf, features);
-                    case "uas54" -> addFeature(FieldValues.CLASS_ISOLATED_DWELLING, 14, sf, features);
+
+                if (Objects.equals(code, "uas2")) {
+                    addFeature(FieldValues.CLASS_PROVINCE, 4, sf, features);
+                } else if (Objects.equals(code, "uas511") && List.of("SOST", "APSK").contains(adm_type)) {
+                    addFeature(FieldValues.CLASS_CITY, 6, sf, features);
+                } else if (Objects.equals(code, "uas511") && (Objects.equals(adm_type, "SAV"))) {
+                    addFeature(FieldValues.CLASS_CITY, 7, sf, features);
+                } else if (Objects.equals(code, "uas511")) {
+                    addFeature(FieldValues.CLASS_TOWN, 8, sf, features);
+                } else if (Objects.equals(code, "uas512"))  {
+                    addFeature(FieldValues.CLASS_TOWN, 9, sf, features);
+                } else if (Objects.equals(code, "uas52") && pop > 200) {
+                    addFeature(FieldValues.CLASS_VILLAGE, 10, sf, features);
+                } else if (Objects.equals(code, "uas52") && pop > 50) {
+                    addFeature(FieldValues.CLASS_VILLAGE, 11, sf, features);
+                } else if (Objects.equals(code, "uas52")) {
+                    addFeature(FieldValues.CLASS_VILLAGE, 12, sf, features);
+                } else if (Objects.equals(code, "uas53")) {
+                    addFeature(FieldValues.CLASS_SUBURB, 11, sf, features);
+                } else if (Objects.equals(code, "uas54")) {
+                    addFeature(FieldValues.CLASS_ISOLATED_DWELLING, 14, sf, features);
                 }
+
             }
         }
     }
 
     void addFeature(String clazz, int minZoom, SourceFeature sf, FeatureCollector features) {
-        var capital = switch (sf.getString("ADM_TIP")) {
+
+        var adm_tip = sf.getString("ADM_TIP");
+
+        var capital = switch (adm_tip) {
+            case "SOST" -> 2;
+            default -> null;
+        };
+
+        var rank = switch (adm_tip) {
             case "SOST" -> 2;
             case "APSK" -> 4;
-            case "SAV" -> 5;
-            case "SEN" -> 6;
-            default -> null;
+            case "SAV" -> 6;
+            case "SEN" -> 8;
+            default -> 12;
         };
 
         features.point(this.name())
@@ -43,6 +70,7 @@ public class Place implements OpenMapTilesSchema.Place {
                 .putAttrs(LanguageUtils.getNames(sf.tags()))
                 .setAttr(Fields.CLASS, clazz)
                 .setAttr(Fields.CAPITAL, capital)
+                .setAttr(Fields.RANK, rank)
                 .setMinZoom(minZoom);
     }
 }


### PR DESCRIPTION
Extend settlements classification using types and population to smoothly display labels on different scales.

In this PR:
- Classification is fixed for cities vs towns. This helps to classify labels on map as well;
- On different scales cities and towns are shown based more on importance;
- Villages on different scales now is included based on population not all at once;
- Add rank to improve labels displaying (based on Open Vector tile schema practice).

Before:
![image](https://github.com/govlt/national-basemap/assets/1758436/38c51022-dcdf-42fe-98fd-b10fe95b10bc)
Now:
![image](https://github.com/govlt/national-basemap/assets/1758436/7e9b6699-eda3-44dc-b6a2-687e0864c279)

Before:
![image](https://github.com/govlt/national-basemap/assets/1758436/bd89f917-8ee2-4fbd-a0f9-6213409d3fb9)
Now:
![image](https://github.com/govlt/national-basemap/assets/1758436/218f9e76-0d7a-4499-bbf2-2bdb5356ff34)

Before:
![image](https://github.com/govlt/national-basemap/assets/1758436/e6715a53-316a-42b1-afd7-6fc087dd5a0d)
Now:
![image](https://github.com/govlt/national-basemap/assets/1758436/6f087367-820e-4908-9e27-8738d2019f17)
