### PR TITLE
Update bridge levels for bright style

### DIFF
--- a/vector/styles/bright/style.json
+++ b/vector/styles/bright/style.json
@@ -2841,6 +2841,36 @@
       }
     },
     {
+      "id": "bridge-minor-casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "minor"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {
+          "stops": [[12, 0], [12.5, 1]]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [12, 0.5],
+            [13, 1],
+            [14, 4],
+            [20, 15]
+          ]
+        }
+      }
+    },
+    {
       "id": "bridge-secondary-tertiary-casing",
       "type": "line",
       "source": "openmaptiles",
@@ -3154,6 +3184,33 @@
               20,
               11.5
             ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-minor",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "minor"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [13.5, 0],
+            [14, 2.5],
+            [20, 11.5]
           ]
         }
       }

--- a/vector/styles/bright/style.json
+++ b/vector/styles/bright/style.json
@@ -3369,6 +3369,61 @@
       }
     },
     {
+      "id": "bridge-trunk-primary-level2-casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"],
+        ["==", "level", 2]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(28, 76%, 67%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [5, 0.4],
+            [6, 0.6],
+            [7, 1.5],
+            [20, 26]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge-trunk-primary-level2",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"],
+        ["==", "level", 2]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [6.5, 0],
+            [7, 0.5],
+            [20, 18]
+          ]
+        }
+      }
+    },
+    {
       "id": "cablecar",
       "type": "line",
       "source": "openmaptiles",


### PR DESCRIPTION
This PR fixes two major problems with Bright style:
- To fix styling issues at 3-level junctions, a level 2 bridge representation has been added;
- Bridges have been added for minor roads, which were originally missing in the Bright style (strange, because this style has, for example, a bridge for a tracks, but side roads were not included).

Before:
![image](https://github.com/govlt/national-basemap/assets/1758436/d49ed8bd-8a6e-4cb2-9dcb-8eb2ce6ac865)

After:
![image](https://github.com/govlt/national-basemap/assets/1758436/89dcfaff-f472-4456-8440-4e0ec3871b36)

Before:
![image](https://github.com/govlt/national-basemap/assets/1758436/45141c4a-f8c6-4669-afa1-5b147449bd71)

After:
![image](https://github.com/govlt/national-basemap/assets/1758436/bae5a299-f642-43f7-bcaf-9881208779fd)

P.S. Positron style does not use multiple levels at all.

