### PR TITLE
Add missing parts of the pedestrian alleys

### DIFF
--- a/vector/src/main/java/lt/lrv/basemap/layers/Transportation.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/Transportation.java
@@ -41,7 +41,8 @@ public class Transportation implements OpenMapTilesSchema.Transportation, Forwar
             case 6, 8 -> addTransportationFeature(FieldValues.CLASS_MINOR, null, 12, sf, features);
             case 7, 9 -> addTransportationFeature(FieldValues.CLASS_SERVICE, null, 13, sf, features);
             case 10, 11 -> addTransportationFeature(FieldValues.CLASS_TRACK, null, 13, sf, features);
-            case 13, 15 -> addTransportationFeature(FieldValues.CLASS_PATH, null, 14, sf, features);
+            case 15 -> addTransportationFeature(FieldValues.CLASS_PATH, null, 13, sf, features);
+            case 13 -> addTransportationFeature(FieldValues.CLASS_PATH, null, 14, sf, features);
             case 14 -> addTransportationFeature(FieldValues.CLASS_FERRY, null, 13, sf, features);
             default -> addTransportationFeature(null, null, 14, sf, features);
         }

--- a/vector/src/main/java/lt/lrv/basemap/layers/Transportation.java
+++ b/vector/src/main/java/lt/lrv/basemap/layers/Transportation.java
@@ -41,7 +41,7 @@ public class Transportation implements OpenMapTilesSchema.Transportation, Forwar
             case 6, 8 -> addTransportationFeature(FieldValues.CLASS_MINOR, null, 12, sf, features);
             case 7, 9 -> addTransportationFeature(FieldValues.CLASS_SERVICE, null, 13, sf, features);
             case 10, 11 -> addTransportationFeature(FieldValues.CLASS_TRACK, null, 13, sf, features);
-            case 13 -> addTransportationFeature(FieldValues.CLASS_PATH, null, 14, sf, features);
+            case 13, 15 -> addTransportationFeature(FieldValues.CLASS_PATH, null, 14, sf, features);
             case 14 -> addTransportationFeature(FieldValues.CLASS_FERRY, null, 13, sf, features);
             default -> addTransportationFeature(null, null, 14, sf, features);
         }


### PR DESCRIPTION
GRPK dataset has specific code for pedestrian alleys. This classification is used very rarely, but quite importantly, for the main alleys (for example Laisvės al. in Kaunas) that are now not on the basemap.

Before:
![image](https://github.com/govlt/national-basemap/assets/1758436/f8e907d4-229d-442e-be65-40cd8221c4fe)
![image](https://github.com/govlt/national-basemap/assets/1758436/86f28d79-f4d9-4a13-8953-bdb19bc66608)

After:
![image](https://github.com/govlt/national-basemap/assets/1758436/6ceca907-6942-4e90-b6d9-792742278106)
![image](https://github.com/govlt/national-basemap/assets/1758436/b6baf841-44a8-4ea6-8732-c7a1a2d7ee3d)




