### PR TITLE
Setup martin image with styles (upgrade martin to v0.18.1)

### DIFF
--- a/vector/docker-compose.yml
+++ b/vector/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     pull_policy: build
     networks:
       - internal
+    environment:
+      - HOST=http://localhost:3000
     restart: unless-stopped
     ports:
       - 3000:3000

--- a/vector/docker/Dockerfile
+++ b/vector/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY vector ./vector
 
 RUN ./gradlew run
 
-FROM ghcr.io/maplibre/martin:v0.13.0
+FROM ghcr.io/maplibre/martin:v0.18.1
 
 # Let's use non root user
 ARG USER=basemap
@@ -23,18 +23,25 @@ USER $USER
 
 WORKDIR /opt/vector
 
+ENV HOST="http://127.0.0.1:3000"
+
+# Entrypoint script
+COPY --chown=$USER:$USER --chmod=755 vector/docker/martin/docker-entrypoint.sh /usr/local/bin/
+
 # Martin configuration
 COPY --chown=$USER:$USER vector/docker/martin/config.yaml config.yaml
 
 # Fonts
 COPY --chown=$USER:$USER vector/styles/fonts  fonts/
 
-# Sprites
-COPY --chown=$USER:$USER vector/styles/openmaptiles/sprites styles/openmaptiles/sprites
-COPY --chown=$USER:$USER vector/styles/positron/sprites styles/positron/sprites
-COPY --chown=$USER:$USER vector/styles/bright/sprites styles/bright/sprites
+# Styles & sprites
+COPY --chown=$USER:$USER vector/styles/openmaptiles styles/openmaptiles
+COPY --chown=$USER:$USER vector/styles/positron styles/positron
+COPY --chown=$USER:$USER vector/styles/bright styles/bright
 
 # Pmtiles
 COPY --chown=$USER:$USER --from=build /app/vector/data/output/lithuania.pmtiles pmtiles/lithuania.pmtiles
 
-CMD ["--config", "config.yaml"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["martin", "--config", "config.yaml"]

--- a/vector/docker/martin/config.yaml
+++ b/vector/docker/martin/config.yaml
@@ -12,3 +12,9 @@ sprites:
 
 fonts:
   - /opt/vector/fonts
+
+styles:
+  sources:
+    bright: /opt/vector/styles/bright/style.json
+    openmaptiles: /opt/vector/styles/openmaptiles/style.json
+    positron: /opt/vector/styles/positron/style.json

--- a/vector/docker/martin/docker-entrypoint.sh
+++ b/vector/docker/martin/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for style_file in styles/*/style.json; do
+    if [ -f "$style_file" ]; then
+        sed -i "s#http://localhost:3000#${HOST}#g" "$style_file"
+    fi
+done
+
+exec "$@"

--- a/vector/preview/martin.Dockerfile
+++ b/vector/preview/martin.Dockerfile
@@ -1,15 +1,21 @@
-FROM ghcr.io/maplibre/martin:v0.13.0
+FROM ghcr.io/maplibre/martin:v0.18.1
+
+ENV HOST="http://127.0.0.1:3000"
 
 WORKDIR /opt/vector
+
+COPY --chmod=755 docker/martin/docker-entrypoint.sh /usr/local/bin/
 
 COPY docker/martin/config.yaml config.yaml
 
 COPY styles/fonts  fonts/
 
-COPY styles/openmaptiles/sprites styles/openmaptiles/sprites
-COPY styles/positron/sprites styles/positron/sprites
-COPY styles/bright/sprites styles/bright/sprites
+COPY styles/openmaptiles styles/openmaptiles
+COPY styles/positron styles/positron
+COPY styles/bright styles/bright
 
 COPY data/output/lithuania.pmtiles pmtiles/lithuania.pmtiles
 
-CMD ["--config", "config.yaml"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["martin", "--config", "config.yaml"]


### PR DESCRIPTION
- ✅  Upgraded martin from v0.13.0 to v0.18.1 (now it supports styles)
- ✅  Setup martin image to serve styles
- ❌  TODO: Update readme how to use `national-basemap-vector-martin`